### PR TITLE
Add func-style and exports-style rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install --save-dev entercom/eslint-config-entercom
 
 Install peer dependencies
 ```
-npm install --save-dev eslint-config-airbnb-base eslint-plugin-import eslint-plugin-mocha eslint-plugin-no-only-tests 
+npm install --save-dev eslint-config-airbnb-base eslint-plugin-import eslint-plugin-jsdoc eslint-plugin-mocha eslint-plugin-no-only-tests eslint-plugin-node
 ```
 
 Add configuration as an extends

--- a/index.js
+++ b/index.js
@@ -1,14 +1,7 @@
 module.exports = {
-  parserOptions: {
-    ecmaVersion: 10,
-    sourceType: 'module',
-    ecmaFeatures: {
-      jsx: true
-    }
-  },
   env: {
-    node: true,
-    es6: true
+    es6: true,
+    node: true
   },
   extends: [
     'eslint:recommended',
@@ -16,51 +9,35 @@ module.exports = {
   ],
   overrides: [
     {
+      env: {
+        es6: true,
+        mocha: true,
+        node: true
+      },
       files: [
         'test/**/*_spec.js'
       ],
       plugins: [
-        'no-only-tests',
-        'mocha'
+        'mocha',
+        'no-only-tests'
       ],
-      env: {
-        node: true,
-        mocha: true,
-        es6: true
-      },
       rules: {
         'no-only-tests/no-only-tests': 2
       }
     }
   ],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    },
+    ecmaVersion: 10,
+    sourceType: 'module'
+  },
   plugins: [
     'jsdoc',
     'node'
   ],
   rules: {
-    'jsdoc/no-undefined-types': 0,
-    'max-len': [
-      'error',
-      {
-        code: 120,
-        ignoreComments: true,
-        ignoreUrls: true,
-        ignoreTemplateLiterals: true
-      }
-    ],
-    'comma-dangle': [
-      'error',
-      'never'
-    ],
-    'no-multiple-empty-lines': [
-      'error',
-      {
-        max: 1,
-        maxBOF: 0,
-        maxEOF: 1
-      }
-    ],
-    camelcase: 0,
     'array-bracket-newline': [
       'error',
       'consistent'
@@ -69,18 +46,23 @@ module.exports = {
       'error',
       'consistent'
     ],
+    camelcase: 0,
+    'comma-dangle': [
+      'error',
+      'never'
+    ],
     'func-style': [
       'error',
       'declaration'
     ],
-    'node/exports-style': [
-      'error',
-      'module.exports'
-    ],
-    'object-curly-newline': [
+    'jsdoc/no-undefined-types': 0,
+    'max-len': [
       'error',
       {
-        consistent: true
+        code: 120,
+        ignoreComments: true,
+        ignoreUrls: true,
+        ignoreTemplateLiterals: true
       }
     ],
     'no-confusing-arrow': 0,
@@ -94,6 +76,14 @@ module.exports = {
         ]
       }
     ],
+    'no-multiple-empty-lines': [
+      'error',
+      {
+        max: 1,
+        maxBOF: 0,
+        maxEOF: 1
+      }
+    ],
     'no-param-reassign': [
       'error',
       {
@@ -105,6 +95,16 @@ module.exports = {
       'error',
       'LabeledStatement',
       'WithStatement'
+    ],
+    'node/exports-style': [
+      'error',
+      'module.exports'
+    ],
+    'object-curly-newline': [
+      'error',
+      {
+        consistent: true
+      }
     ]
   }
 };

--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ module.exports = {
       }
     }
   ],
+  plugins: [
+    'jsdoc',
+    'node'
+  ],
   rules: {
     'jsdoc/no-undefined-types': 0,
     'max-len': [
@@ -64,6 +68,14 @@ module.exports = {
     'array-element-newline': [
       'error',
       'consistent'
+    ],
+    'func-style': [
+      'error',
+      'declaration'
+    ],
+    'node/exports-style': [
+      'error',
+      'module.exports'
     ],
     'object-curly-newline': [
       'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-entercom",
+  "name": "@entercom/eslint-config-entercom",
   "version": "1.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-import": ">=2",
     "eslint-plugin-jsdoc": ">=20",
     "eslint-plugin-mocha": ">=6",
-    "eslint-plugin-node": ">=11",
-    "eslint-plugin-no-only-tests": ">=2"
+    "eslint-plugin-no-only-tests": ">=2",
+    "eslint-plugin-node": ">=11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "eslint": ">=5",
     "eslint-config-airbnb-base": ">=13",
     "eslint-plugin-import": ">=2",
+    "eslint-plugin-jsdoc": ">=20",
     "eslint-plugin-mocha": ">=6",
+    "eslint-plugin-node": ">=11",
     "eslint-plugin-no-only-tests": ">=2"
   }
 }


### PR DESCRIPTION
This PR adds the `func-style` rule (built into eslint) and the `exports-style` rule (from the `eslint-plugin-node` package). See https://eslint.org/docs/rules/func-style and https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/exports-style.md for details. These rules bring our other microservices inline with radio-api in regards to these two styles.