### PR TITLE
Add func-style & node/exports-style rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ module.exports = {
     ecmaVersion: 10,
     sourceType: 'module'
   },
+  plugins: [
+    'jsdoc',
+    'node'
+  ],
   rules: {
     'array-bracket-newline': [
       'error',
@@ -46,6 +50,10 @@ module.exports = {
     'comma-dangle': [
       'error',
       'never'
+    ],
+    'func-style': [
+      'error',
+      'declaration'
     ],
     'jsdoc/no-undefined-types': 0,
     'max-len': [
@@ -87,6 +95,10 @@ module.exports = {
       'error',
       'LabeledStatement',
       'WithStatement'
+    ],
+    'node/exports-style': [
+      'error',
+      'module.exports'
     ],
     'object-curly-newline': [
       'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -440,9 +440,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-20.0.3.tgz",
-      "integrity": "sha512-h/f9skf8oFmYg7jJfV2P43ciBV78q0dxkpnL++zPJrbuV4ZRCSlFmQWjjlNgNfYLGfAl166SNjGg7veEEVX9oA==",
+      "version": "20.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-20.0.5.tgz",
+      "integrity": "sha512-hSGCKkrydrwfwlSo+6BEHZ8tUm4SwJ+96dINdDGn5jYwmiQOkAq+aYVOusVjVGWSJ/kKqDJCWVp99jt8K6Prkw==",
       "requires": {
         "comment-parser": "^0.7.2",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-jsdoc": "^20.0.5",
     "eslint-plugin-mocha": "^6.2.2",
-    "eslint-plugin-no-only-tests": "^2.4.0"
+    "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-node": "^11.0.0"
   }
 }


### PR DESCRIPTION
This adds the `func-style` rule (built into eslint) and the `node/exports-style` rule (from the `eslint-plugin-node` package). See https://eslint.org/docs/rules/func-style and https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/exports-style.md for details. These rules bring our other microservices inline with radio-api in regards to these two styles.